### PR TITLE
Fixed incorrect namespace name in 'provides' section

### DIFF
--- a/META.info
+++ b/META.info
@@ -4,7 +4,7 @@
   "description" : "Utility for automating bundling up your package",
   "author"      : "Tony ODell",
   "provides"    : {
-    "Pandapack6" : "lib/Pandapack.pm6"
+    "Pandapack" : "lib/Pandapack.pm6"
   },
   "depends"     : [
     "Pluggable"


### PR DESCRIPTION
This fixes my error in the PR #1 I sent yesterday. There should not be a '6' at the end of the namespace name. Sorry.
